### PR TITLE
Use 0 as default index

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ class TSL5 extends EventEmitter {
         let bufUMD = Buffer.alloc(12)
 
         if (!tally.index) { 
-            tally.index = 1 //default to index 1
+            tally.index = 0 //default to index 0
         }
     
         bufUMD.writeUInt16LE(tally.screen, this._SCREEN) 


### PR DESCRIPTION
Fixes issue where it was impossible to set index to 0, as it is falsy, and would be set to 1 Makes more sense to have 0 as default, as it is the first valid index