### PR TITLE
Allow index = 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ class TSL5 extends EventEmitter {
     constructPacket(tally, sequence) {
         let bufUMD = Buffer.alloc(12)
 
-        if (!tally.index) { 
+        if (tally.index !== 0 && !tally.index) { 
             tally.index = 1 //default to index 1
         }
     


### PR DESCRIPTION
Allow index === 0 instead of defaulting to 1, while still defaulting falsy values to 1. This should not break anything and add support for situations where index must be 0 (e.g. Shotoku Panels)